### PR TITLE
Add new mutation strategies

### DIFF
--- a/go-fuzz/mutator.go
+++ b/go-fuzz/mutator.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strconv"
 
+	. "github.com/dvyukov/go-fuzz/go-fuzz-defs"
 	"github.com/dvyukov/go-fuzz/go-fuzz/internal/pcg"
 )
 


### PR DESCRIPTION
This PR adds new mutation strategies for the inputs:
- InsertRepeatedBytes: A sequence of the same bytes is inserted at a random position into the input
- ShuffleBytes: The bytes of a subslice of the input are shuffled to random positions
- LEB128 Encoding: Integer Literals can be encoded with (unsigned | signed) Little Endian Base 128